### PR TITLE
Define options is done in AddLettuceEncrypt

### DIFF
--- a/test/Integration/README.md
+++ b/test/Integration/README.md
@@ -25,14 +25,14 @@ To test this project, I recommend the following steps.
 4. Set your app to use Let's Encrypt staging environment so you don't hit rate limits in generating certificates.
 
 ```csharp
-    .UseLettuceEncrypt(o =>
+    services.AddLettuceEncrypt(o =>
     {
         o.DomainNames = new[] { "TMP.ngrok.io" };
         o.UseStagingServer = true; // <--- use staging
 
         o.AcceptTermsOfService = true;
         o.EmailAddress = "admin@example.com";
-    })
+    });
 ```
 
 5. `dotnet run` your application.


### PR DESCRIPTION
It looks like this has changed at some poinit, but you cannot define the options in the UseLettuceEncrypt-Call, but you can use it during AddLetuceEncrypt.